### PR TITLE
Add cluster/environment tags to AZP nodes

### DIFF
--- a/azure/terraform/examples/tf-aks-azp1/aks.tf
+++ b/azure/terraform/examples/tf-aks-azp1/aks.tf
@@ -96,6 +96,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "aksNodePools" {
     each.value.node_labels
   )
 
+  tags = {
+    azp_cluster = var.environmentShort
+  }
+
   availability_zones = [
     "1",
     "2",


### PR DESCRIPTION
Add cluster/environment tags to AZP nodes to easier identify AZP nodes in monitoring. 